### PR TITLE
Added support for version 1.

### DIFF
--- a/includes/wp-rest-api-frontpage-v1.php
+++ b/includes/wp-rest-api-frontpage-v1.php
@@ -1,0 +1,80 @@
+<?php
+/**
+ * WP REST API Frontpage Routes
+ *
+ * @package WP_REST_API_frontpage
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+    exit; // Exit if accessed directly
+}
+
+if ( ! class_exists( 'WP_JSON_API_frontpage' ) ) :
+
+
+  /**
+   * WP REST API frontpage class.
+   *
+   * WP REST API frontpage support for WP API v2.
+   *
+   * @package WP_REST_API_frontpage
+   * @since 1.0.1
+   */
+  class WP_JSON_API_frontpage {
+
+
+    /**
+     * Register menu routes for WP API v2.
+     *
+     * @since  1.0.1
+     */
+    public function register_routes($routes) {
+
+      $routes['/frontpage'] = array(
+				array( array( $this, 'get_frontpage' ), WP_JSON_Server::READABLE ),
+			);
+
+      return $routes;
+    }
+
+
+    /**
+     * Get the frontpage
+     *
+     * @since  1.0.1
+     * @return Object of the frontpage (pageObject)
+     */
+    public static function get_frontpage() {
+
+      // Get the ID of the static frontpage. If not set it's 0
+      $page_id = get_option('page_on_front');
+
+      // If the Frontpage is set, it's id shouldn't be 0
+      if ( $page_id > 0 ) {
+
+        // Set url for call to retrieve the post, need WP REST API for this
+        $endpoint = get_json_url() . '/pages/' . $page_id;
+
+        // Do the actual call to retrieve the pageObject by ID
+        $response = file_get_contents($endpoint);
+
+        // Decode the output
+        $output = json_decode($response);
+
+      } else {
+        $output = null;
+      }
+
+      // No static frontpage is set
+      if( empty($output) ) {
+        return new WP_Error( 'wpse-error', 
+          esc_html__( 'No Static Frontpage set', 'wpse' ), 
+          [ 'status' => 404 ] );
+      }
+
+      // Response setup
+      return $output;
+    }
+  }
+
+endif;

--- a/wp-rest-api-frontpage.php
+++ b/wp-rest-api-frontpage.php
@@ -34,6 +34,8 @@ if ( ! defined( 'ABSPATH' ) ) {
   exit; // Exit if accessed directly
 }
 
+// WP API v1.
+include_once 'includes/wp-rest-api-frontpage-v1.php';
 // WP API v2.
 include_once 'includes/wp-rest-api-frontpage-v2.php';
 
@@ -45,8 +47,14 @@ if ( ! function_exists ( 'wp_rest_api_frontpage_init' ) ) :
    * @since 1.0.0
    */
   function wp_rest_api_frontpage_init() {
-    $class = new WP_REST_API_frontpage();
-    add_filter( 'rest_api_init', array( $class, 'register_routes' ) );
+
+    if ( ! defined( 'JSON_API_VERSION' ) && ! in_array( 'json-rest-api/plugin.php', get_option( 'active_plugins' ) ) ) {
+      $class = new WP_REST_API_frontpage();
+      add_filter( 'rest_api_init', array( $class, 'register_routes' ) );
+		} else {
+			$class = new WP_JSON_API_frontpage();
+			add_filter( 'json_endpoints', array( $class, 'register_routes' ) );
+		}
   }
 
   add_action( 'init', 'wp_rest_api_frontpage_init' );


### PR DESCRIPTION
I've basically followed the example I saw on WP REST API Menus to create version 1 support. Seems to be working fine, it pulls up the front page as it should on WP REST API version 1.2.5.