### PR TITLE
Fix WP error message

### DIFF
--- a/includes/wp-rest-api-frontpage-v2.php
+++ b/includes/wp-rest-api-frontpage-v2.php
@@ -88,9 +88,9 @@ if ( ! class_exists( 'WP_REST_API_frontpage' ) ) :
 
       // No static frontpage is set
       if( empty($response) ) {
-        return new WP_Error( 'wpse-error',
+        return new WP_Error( '404', 'wpse-error',
           esc_html__( 'No Static Frontpage set', 'wpse' ),
-          [ 'status' => 404 ] );
+        );
       }
 
       // Return the response


### PR DESCRIPTION
WP_Error should accept status as first parameter [according to codex](https://codex.wordpress.org/Class_Reference/WP_Error). This should prevent the plugin from erroring when trying to activate.